### PR TITLE
Add security policy for vulnerability reporting

### DIFF
--- a/security.md
+++ b/security.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+## Purpose
+
+This document outlines how security vulnerabilities should be reported for this
+repository.
+
+HMCTS is committed to responsible vulnerability disclosure and to addressing
+legitimate security issues in a timely and coordinated manner.
+
+## Reporting a vulnerability
+
+If you believe you have identified a security vulnerability in this repository, please report it by email to: 
+
+HMCTSVulnerabilityDisclosure@justice.gov.uk
+
+This email address is the sole approved point of contact for vulnerability disclosures relating to HMCTS-owned repositories and services.
+
+Please **do not** create public GitHub issues or pull requests to report security vulnerabilities.
+
+## What to Include in a Report
+
+When reporting a vulnerability, please provide as much of the following information as possible:
+
+- The repository, service, or component affected
+- A clear description of the vulnerability
+- Steps required to reproduce the issue
+- Any non-destructive proof of concept or exploitation details
+
+Where available, the following additional information is helpful:
+
+- The suspected vulnerability type (for example, an OWASP category)
+- Relevant logs, screenshot or error messages
+
+Reports do not need to be fully validated before submission. If you are unsure whether an issue is exploitable or security-relevant, you are still encouraged to report it.
+
+## Responsible Disclosure Guidelines
+
+When investigating or reporting a vulnerability affecting HMCTS systems, reporters must not:
+
+- Break the law or breach applicable regulations
+- Access unnecessary, excessive, or unrelated data
+- Modify or delete data
+- Perform denial-of-service or other disruptive testing
+- Use high-intensity, invasive, or destructive scanning techniques
+- Publicly disclose the vulnerability before it has been addressed
+- Attempt social engineering, Phishing, or physical attacks
+- Demand payment or compensation in exchange for disclosure
+
+These guidelines are intended to protect users, services, and data while allowing good-faith security research.
+
+
+## Bug Bounty
+
+HMCTS does not operate a paid bug bounty programme.
+
+## Code of Conduct
+
+All contributors and reporters are expected to act in good faith and in accordance with applicable laws and professional standards.
+
+## Further Reading
+
+- https://www.ncsc.gov.uk/information/vulnerability-reporting
+- https://www.gov.uk/help/report-vulnerability
+- https://github.com/Trewaters/security-README


### PR DESCRIPTION
This document outlines the process for reporting security vulnerabilities in the repository, including guidelines for responsible disclosure and what information to include in a report.

