### PR TITLE
Pin Infrastructure library to 2.4.4

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -4,7 +4,7 @@ properties([
         pipelineTriggers([cron('H 08 * * 1-5')])
 ])
 
-@Library("Infrastructure") _
+@Library("Infrastructure@2.4.4") _
 
 def product = "fact"
 def component = "citizen"


### PR DESCRIPTION
Updates Jenkinsfile_nightly to use Infrastructure library version 2.4.4.